### PR TITLE
feat(SNW-179): Add title alignment to TextColumnDouble component

### DIFF
--- a/src/components/dynamics/text-column-double.json
+++ b/src/components/dynamics/text-column-double.json
@@ -203,6 +203,26 @@
       "repeatable": true,
       "component": "basics.image-link",
       "required": false
+    },
+    "first_title_alignment": {
+      "type": "enumeration",
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "default": "left",
+      "required": true
+    },
+    "second_title_alignment": {
+      "type": "enumeration",
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "default": "left",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
### `first_title_alignment` and `second_title_alignment` fields were added to handle the title alignment of each column, they can be aligned to the left, center or right.
![image](https://user-images.githubusercontent.com/100874861/234972789-29ece642-35c0-44e6-a3ea-883be3a6af82.png)
