### PR TITLE
feat(SNW-192): Add Card background color to Grid component

### DIFF
--- a/src/components/dynamics/grid.json
+++ b/src/components/dynamics/grid.json
@@ -79,6 +79,14 @@
       "repeatable": false,
       "component": "basics.component-colors",
       "required": false
+    },
+    "card_background_color": {
+      "type": "string",
+      "required": false
+    },
+    "card_background_hover_color": {
+      "type": "string",
+      "required": false
     }
   }
 }


### PR DESCRIPTION
### The `card_background_color` and `card_background_hover_color` fields were added to the grid component, this will handle the color of the cards.

![image](https://github.com/stakeordie/strapiV4/assets/100874861/22c5ac8c-bc19-4ab4-9936-74a2f053e9bc)
