### PR TITLE
feat(SNW-187): Adjust Custom Carousel component

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "4.10.5",
-	"lastUpdateCheck": 1684874289422,
-	"lastNotification": 1684432613165
+	"latest": "4.10.6",
+	"lastUpdateCheck": 1685121980422,
+	"lastNotification": 1685121980402
 }

--- a/src/components/dynamics/custom-carousel.json
+++ b/src/components/dynamics/custom-carousel.json
@@ -68,6 +68,11 @@
       "type": "component",
       "repeatable": false,
       "component": "basics.component-colors"
+    },
+    "hide_scroll_arrows": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }


### PR DESCRIPTION
`hide_scroll_arrows` and `title_size` fields were added to Custom Carousel component, where you can handle the title size (h1-h6)in the carosuel cards as same as to hide or show the scroll arrows.

![image](https://github.com/stakeordie/strapiV4/assets/100874861/8073f6b4-9b7e-4f08-9cf0-4515edb2f40f)
