### PR TITLE
feat(SNW-185): Add video support to TextImageColumn component

### DIFF
--- a/src/components/dynamics/text-image-column-double.json
+++ b/src/components/dynamics/text-image-column-double.json
@@ -20,7 +20,8 @@
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images"
+        "images",
+        "videos"
       ]
     },
     "image_description": {
@@ -180,6 +181,9 @@
       "repeatable": true,
       "component": "basics.image-link",
       "required": false
+    },
+    "video_url": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
The `image` field was adjusted to support videos, also there is a new field added `video_url`, you can input a Youtube video URL and it wil be displayed on the component.

![image](https://github.com/stakeordie/strapiV4/assets/100874861/7ebfa7a2-2d94-47d2-a44e-d5bc9e479b24)
