### PR TITLE
feat(SNW-193): Add Extra Large padding option

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
 	"latest": "4.10.6",
-	"lastUpdateCheck": 1685121980422,
+	"lastUpdateCheck": 1685478209665,
 	"lastNotification": 1685121980402
 }

--- a/src/components/dynamic-heros/basic-hero.json
+++ b/src/components/dynamic-heros/basic-hero.json
@@ -26,7 +26,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -37,7 +38,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/article-image.json
+++ b/src/components/dynamics/article-image.json
@@ -27,7 +27,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none"
     },
@@ -37,7 +38,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small"
     },

--- a/src/components/dynamics/article-video.json
+++ b/src/components/dynamics/article-video.json
@@ -27,7 +27,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none"
     },
@@ -37,7 +38,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small"
     },

--- a/src/components/dynamics/component-sizes.json
+++ b/src/components/dynamics/component-sizes.json
@@ -36,7 +36,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true
@@ -47,7 +48,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/cta-button.json
+++ b/src/components/dynamics/cta-button.json
@@ -32,7 +32,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true
@@ -43,7 +44,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/custom-carousel.json
+++ b/src/components/dynamics/custom-carousel.json
@@ -41,7 +41,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true
@@ -52,7 +53,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"

--- a/src/components/dynamics/custom-table.json
+++ b/src/components/dynamics/custom-table.json
@@ -18,7 +18,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"
@@ -29,7 +30,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"

--- a/src/components/dynamics/divider.json
+++ b/src/components/dynamics/divider.json
@@ -13,7 +13,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small"
     },
@@ -23,7 +24,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small"
     },

--- a/src/components/dynamics/ecosystem.json
+++ b/src/components/dynamics/ecosystem.json
@@ -24,7 +24,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"
@@ -35,7 +36,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"

--- a/src/components/dynamics/grid.json
+++ b/src/components/dynamics/grid.json
@@ -58,7 +58,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -69,7 +70,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/infinite-carousel.json
+++ b/src/components/dynamics/infinite-carousel.json
@@ -16,7 +16,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"
@@ -27,7 +28,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "required": true,
       "default": "small"

--- a/src/components/dynamics/text-column-double.json
+++ b/src/components/dynamics/text-column-double.json
@@ -91,7 +91,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -102,7 +103,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/text-column-single.json
+++ b/src/components/dynamics/text-column-single.json
@@ -79,7 +79,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -90,7 +91,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/text-image-column-double.json
+++ b/src/components/dynamics/text-image-column-double.json
@@ -102,7 +102,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -113,7 +114,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true

--- a/src/components/dynamics/three-column-resource.json
+++ b/src/components/dynamics/three-column-resource.json
@@ -28,7 +28,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "none",
       "required": true
@@ -39,7 +40,8 @@
         "none",
         "small",
         "medium",
-        "large"
+        "large",
+        "extra-large"
       ],
       "default": "small",
       "required": true


### PR DESCRIPTION
### The `extra-large` option was added to all `padding_top` and `padding_bottom` fields on all dynamic components, this will render a 128px padding.

![image](https://github.com/stakeordie/strapiV4/assets/100874861/fa51d805-089b-4679-b8df-524a405c02a0)
