### PR TITLE
feat(SNW-196): Add width option to Grid component

### DIFF
--- a/src/components/dynamics/grid.json
+++ b/src/components/dynamics/grid.json
@@ -89,6 +89,15 @@
     "card_background_hover_color": {
       "type": "string",
       "required": false
+    },
+    "width": {
+      "type": "enumeration",
+      "enum": [
+        "standard",
+        "wide"
+      ],
+      "default": "wide",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
### `width` field was added to the Grid component with `standard` and `wide` options

![image](https://github.com/stakeordie/strapiV4/assets/100874861/a9325be5-1693-48b7-9643-ddcf79a7a1f7)
